### PR TITLE
Corrected links in slack from jenkins for this version

### DIFF
--- a/Jenkins/Jenkinsfile.common.Groovy
+++ b/Jenkins/Jenkinsfile.common.Groovy
@@ -528,7 +528,7 @@ def slackReportLineArtifactory() {
 def slackReportLineDocumentation() {
     return "Documentation: <https://imageware.atlassian.net/wiki/spaces/MA/pages/755204122/How+To+Integrate+Sample+App+Details|How To Use Sample App>" +
             " - <https://imageware.atlassian.net/wiki/spaces/MA/pages/704938246/Integration.txt+for+adding+GMI+SDK+libraries+to+an+app|SDK integration.txt>" +
-            " - <https://artifactory.iwsinc.com:8442/artifactory/webapp/#/artifacts/browse/tree/General/GoVerifyID/Android/SDKs/7.6.18/ims_android_7.6.19_JavadocAPI.zip|SDK 7.6.19 JavaDoc API>\n"
+            " - <https://artifactory.iwsinc.com:8442/artifactory/webapp/#/artifacts/browse/tree/General/GoVerifyID/Android/SDKs/7.7.1/ims_android_7.7.1_JavadocAPI.zip|SDK 7.7.1 JavaDoc API>\n"
 }
 
 def slackReportLineJenkins(boolean includeTests = true) {


### PR DESCRIPTION
## This PR addresses the following issues: 
Just a correction to the URL that is output for the SDK javadoc for this sample app

### Context

In one or two sentences, what problem is this PR trying to solve?
Just a correction to the URL that is output for the SDK javadoc for this sample app


### Approach

Briefly, how does this PR solve the issue?
I just changed the URL manually

### Testing

What was your strategy for testing the new code?
Kicked off a new Jenkins build to see what comes out the other end.  https://jenkins-ent.iwsinc.com/view/GoVerifyID/job/Android-IWS-GMI-SDK-Sample-App/24/

This came out the other end, slack post: https://imageware.slack.com/archives/CD03JH126/p1592528054001400

NEW Android GMI jumpstart_sample_android release available: 1.1
Documentation: How To Use Sample App - SDK integration.txt - SDK 7.7.1 JavaDoc API
Jenkins: Login - Android-IWS-GMI-SDK-Sample-App - build #24 prod: true
Artifactory: jumpstart_sample_android-1.1
GitHub: Tag 1.1 - master

### Misc.

Screenshots? Loose ends? Concerns?
Nah, should be good.